### PR TITLE
Switch Travis-CI to Trusty release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-# Default OS image is Ubuntu 12.04 LTS Precise on Travis-CI for linux
+# Default OS image is Ubuntu 14.04 LTS Trusty on Travis-CI for linux
 language: c
+
+dist: trusty
 
 os:
   - linux
@@ -38,9 +40,7 @@ addons:
       - libgtk2.0-dev
 
 before_install:
-    # make sure to use default 1.9.3 ruby (switching sudo on, does add different ruby versions, GRR!)
-    #  - rvm use 1.9.3 --install --binary --fuzzy
-    #  disabled, because rvm 1.9.3 is not available anymore
+  - rvm reset
     # Really checkout the current branch (needed for commit/push later)
   - git checkout $TRAVIS_BRANCH
     # Update Vim


### PR DESCRIPTION
Travis CI fails, because rvm cannot install ruby 1.9.3

Since we are using Ubuntu Precise (12.04), let's make the switch to
Ubuntu 14.04

This should hopefully make it build again