### PR TITLE
release: provide a nicer release log

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-updates:
+  check-updates-job:
     runs-on: ubuntu-latest
 
     outputs:
       updated: ${{ steps.check-updates.outputs.updated }}
+      appimagetag: ${{ steps.check-updates.outputs.appimagetag }}
 
     steps:
       - name: Set up param
@@ -52,20 +53,22 @@ jobs:
         run: |
           appimage_tag=${{ fromJSON(steps.latest-tags.outputs.data).appimage.refs.edges[0].node.name }}
           vim_tag=${{ fromJSON(steps.latest-tags.outputs.data).vim.refs.edges[0].node.name }}
+          echo "appimagetag=${appimage_tag}" >> "$GITHUB_OUTPUT"
           echo "updated=$([[ ${appimage_tag} != ${vim_tag} ]] && echo true)" >> "$GITHUB_OUTPUT"
 
-  create-appimage:
+  create-appimage-job:
     runs-on: ubuntu-18.04
 
-    needs: check-updates
+    needs: check-updates-job
 
-    if: needs.check-updates.outputs.updated == 'true'
+    if: needs.check-updates-job.outputs.updated == 'true'
 
     env:
       CC: gcc
       TERM: xterm
       DISPLAY: ':99'
       DEBIAN_FRONTEND: noninteractive
+      VIM_REF: ${{ needs.check-updates-job.outputs.appimagetag }}
 
     steps:
       - uses: actions/checkout@v3
@@ -121,10 +124,10 @@ jobs:
           bash scripts/dump_failed_screentests.sh
 
       - name: Create GVim AppImage
-        run: bash -ex scripts/appimage.sh GVim
+        run: bash -e scripts/appimage.sh GVim
 
       - name: Create Vim AppImage
-        run: bash -ex scripts/appimage.sh Vim
+        run: bash -e scripts/appimage.sh Vim
 
       - name: Commit and push
         id: commit

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -99,19 +99,6 @@ find . -name "libX*" -delete
 delete_blacklisted
 
 ########################################################################
-# Determine the version of the app; also include needed glibc version
-########################################################################
-
-if [ -n "$GITHUB_ACTIONS" ]; then
-    # Create release file
-    dl_counter="![Github Downloads (by Release)](https://img.shields.io/github/downloads/$GITHUB_REPOSITORY/${VERSION}/total.svg)"
-    version_info="**GVim: $VERSION** - Vim git commit: [$GIT_REV](https://github.com/vim/vim/commit/$GIT_REV) - glibc: $(glibc_needed)"
-    gha_build="[GitHub Actions Logfile]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
-
-    echo "$dl_counter<br><br>Version Information:<br>$version_info<br><br>$gha_build" >  "$GITHUB_WORKSPACE/release.body"
-fi
-
-########################################################################
 # Patch away absolute paths; it would be nice if they were relative
 ########################################################################
 
@@ -167,6 +154,16 @@ if [ -n "$GITHUB_ACTIONS" ]; then
     echo "Copy $BUILD_BASE/out/$TARGET_NAME -> $GITHUB_WORKSPACE"
     cp "$BUILD_BASE/out/$TARGET_NAME" "$GITHUB_WORKSPACE"
     cp "$BUILD_BASE/out/$TARGET_NAME.zsync" "$GITHUB_WORKSPACE"
+fi
+
+########################################################################
+# Create Github Release
+########################################################################
+
+if [ -n "$GITHUB_ACTIONS" ]; then
+  pushd "$script_dir"
+  . release_notes.sh > "$GITHUB_WORKSPACE/release.body"
+  popd
 fi
 
 ########################################################################

--- a/scripts/release_notes.sh
+++ b/scripts/release_notes.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -e
+vimcommiturl="https://github.com/vim/vim/commit/"
+dl_counter="![Github Downloads (by Release)](https://img.shields.io/github/downloads/$GITHUB_REPOSITORY/${VERSION}/total.svg)"
+version_info="**GVim: $VERSION** - Vim git commit: [$GIT_REV](${vimcommiturl}${GIT_REV}) - glibc: ${GLIBC_NEEDED}"
+gha_build="[GitHub Actions Logfile]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+
+vimlog_md=$(git -C ../vim log --pretty='format:%H %s' $VIM_REF..$GIT_REV | sed \
+    -e 's/[][_*^<`\\]/\\&/g' \
+    -e "s#^\([0-9a-f]*\) patch \([0-9.a-z]*\)#* [\2]($commiturl\1)#" \
+    -e "s#^\([0-9a-f]*\) \(.*\)#* [\2]($commiturl\1)#")
+
+if [ -z "$vimlog_md" ]; then
+  vimlog_md="_No changes unfortunately_ :worried:"
+fi
+
+cat <<EOF
+## Vim AppImage Release ${VERSION}
+$dl_counter<br><br>Version Information:<br>$version_info<br><br>$gha_build
+<hr>
+
+### Downloads
+This release provides the following Artifacts:
+* [![GVim-${VERSION}.Appimage](https://img.shields.io/github/downloads/${GITHUB_REPOSITORY}/${VERSION}/GVim-${VERSION}.glibc${GLIBC_NEEDED}-x86_64.AppImage.svg?label=downloads&logo=vim)](https://github.com/${GITHUB_REPOSITORY}/releases/download/${VERSION}/GVim-${VERSION}.glibc${GLIBC_NEEDED}-x86_64.AppImage)
+* [![Vim-${VERSION}.Appimage](https://img.shields.io/github/downloads/${GITHUB_REPOSITORY}/${VERSION}/Vim-${VERSION}.glibc${GLIBC_NEEDED}-x86_64.AppImage.svg?label=downloads&logo=vim)](https://github.com/${GITHUB_REPOSITORY}/releases/download/${VERSION}/Vim-${VERSION}.glibc${GLIBC_NEEDED}-x86_64.AppImage)
+<p/>
+
+### Changelog
+$vimlog_md
+
+### What is the Difference between the GVim and the Vim Appimage?
+The difference between the GVim and Vim Appimage is, that the GVim version includes a graphical User Interface (GTK3) and other X11 features like clipboard handling. That means, for proper clipboard support, you'll **need** the GVim Appimage, but you can only run this on a system that has the X11 libraries installed. <p/>
+
+For a Server or headless environment, you are probably be better with the Vim version.<p/> _Note_: The image is based on Ubuntu 18.04 LTS bionic. It most likely won't work on older distributions.
+EOF
+
+cat <<'EOF'
+### Run it
+Download the AppImage, make it executable then you can just run it:
+```bash
+wget -O /tmp/gvim.appimage https://github.com/vim/vim-appimage/releases/download/[...]/GVim-[...]_64.AppImage
+chmod +x /tmp/gvim.appimage
+/tmp/gvim.appimage
+```
+
+That's all, you should have a graphical vim now running (if you have a graphical system running) :smile: 
+
+If you want a terminal Vim (with X11 and clipboard feature enabled), just create a symbolic link with a name starting with "vim". Like:
+```bash
+ln -s /tmp/gvim.appimage /tmp/vim.appimage
+```
+
+Then execute `vim.appimage` to get a terminal Vim.
+
+### More Information
+If you need a dynamic interface to Perl, Python2, Python3.8, Ruby or Lua make sure your system provides the needed dynamic libraries (e.g. libperlX, libpython2.7 libpython3X liblua5X and librubyX) as those are **not** distributed together with the image to not make the image too large.
+
+However, Vim will work without those libraries, but some plugins might need those additional dependencies. This means, those interpreters have to be installed in addition to Vim. Without it Vim won't be able to use those dynamic interfaces.
+EOF


### PR DESCRIPTION
Currently the Release page is a bit terse. This commit makes it a bit more nicer for the users:
- it directly links the artifacts for download
- it mentions what artifact to use for what use case
- it mentions how to run it
- it directly links to the Vim Commits since the last change

The release page will be generated by the scripts/release_notes.sh script, but since it needs access to the various environment properties of the appimage.sh script, it will not be called, but rather be source, that's why it's using the '. release_notes.sh' syntax, so that it is executed in the current shell environment.

Also, while at it, slightly refactor the Github Actions release workflow and rename the jobs with the `-job` prefix, so that there does no longer exist a `check-updates` job as well as `check-updates` step, which is confusing if you need to reference the output variable.