### PR TITLE
package /usr/lib/x86_64-linux-gnu/gio/modules/*

### DIFF
--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -79,6 +79,11 @@ find "${SOURCE_DIR}" -xdev -name "vim48x48.png" -exec cp {} "${LOWERAPP}.png" \;
 
 mkdir -p ./usr/lib/x86_64-linux-gnu
 
+if [[ "$LOWERAPP" == "gvim" ]]; then
+  # package the gio plugins for the GUI
+  cp -a /usr/lib/x86_64-linux-gnu/gio ./usr/lib/x86_64-linux-gnu/
+fi
+
 # copy dependencies
 copy_deps
 

--- a/scripts/vim.start.sh
+++ b/scripts/vim.start.sh
@@ -7,6 +7,8 @@ if [ -z "$VIMRUNTIME" ]; then
     export VIMRUNTIME=$APPDIR/usr/share/vim/vim90
 fi
 
+export GIO_MODULE_DIR=$APPDIR/usr/lib/x86_64-linux-gnu/gio/modules
+
 # We don't pack Python stuff, so unset the PYTHON vars set by AppRun.
 # see https://github.com/AppImage/AppImageKit/blob/master/src/AppRun.c
 unset PYTHONPATH


### PR DESCRIPTION
This prevents the ugly error at startup by packaging the gio modules as well.
```
/usr/lib/x86_64-linux-gnu/gvfs/libgvfscommon.so: undefined symbol: g_task_set_name
Failed to load module: /usr/lib/x86_64-linux-gnu/gio/modules/libgioremote-volume-monitor.so
```

closes #32