### PR TITLE
appimage.sh: detect vim/gvim self name

### DIFF
--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -34,12 +34,19 @@ make_appimage()
 
 	pushd ${APP}.AppDir
 	cat <<'EOF' > AppRun
-#!/bin/bash
-HERE="$(dirname "$(readlink -f "${0}")")"
+#!/bin/sh
+set -ue
+: "${ARGV0:=$0}"  # run without AppImage too
+this_dir=$(readlink -f "$0")
+this_dir=${this_dir%/*}  # empty for '/'
+VIMRUNTIME=${this_dir}/usr/share/vim/vim91; export VIMRUNTIME
+test -x "${this_dir}/usr/bin/gvim" || ARGV0=/vim
+case "${ARGV0##*/}" in
+  (vim*) set -- "${this_dir}/usr/bin/vim"  "$@" ;;
+  (*)    set -- "${this_dir}/usr/bin/gvim" "$@" ;;
+esac
 unset ARGV0
-export VIMRUNTIME=${HERE}/usr/share/vim/vim91
-test -L "${HERE}/usr/bin/gvim" && exec "${HERE}/usr/bin/gvim" "${@+"$@"}"
-exec "${HERE}/usr/bin/vim" "${@+"$@"}"
+exec "$@"
 EOF
 	popd
 


### PR DESCRIPTION
- appimages pass `$ARGV0` to AppRun: use it to detect vim/gvim
- extracting Vim.appimage to an AppDir, symlinking AppRun to vim works

- currently impossible to extract GVim.appimage and symlink AppRun b/c:
  - GVim.appimage uses linuxdeploy-plugin-gtk, which renames AppRun to *.wrapped and generates its own AppRun
  - this plugin-generated AppRun, if symlinked, tries to source hooks from the wrong dir (`dirname` / `readlink` order)
  - OTOH calling `AppDir/**/AppRun.wrapped` directly / via symlink bypasses those hooks and thus fails to set GTK vars
  - proposed: add an AppDirRun script for users who extract; document it
  - or: patch/replace AppRun *after* plugin-gtk generates it but *before* the appimage is packaged.

- notes:
  - renamed `$HERE` to `$this_dir`, which linuxdeploy-plugin-gtk already clobbers (not explicitly exported, but might be in user's env)
  - resolving `$0` in `AppRun[.wrapped]` is pointless when run from appimage (`$0` is `/tmp/.mount*/AppRun[.wrapped]`).
  - both "our" AppRun and linuxdeploy-lugin-gtk's call utilities without a `--` guard before args, thus AppDirs can't be named `-...`