### PR TITLE
build_vim.sh: enable py3 (dyn), disable py2

### DIFF
--- a/scripts/build_vim.sh
+++ b/scripts/build_vim.sh
@@ -13,8 +13,9 @@ export CFLAGS="-Wno-deprecated-declarations"
 
 typeset -a CFG_OPTS
 CFG_OPTS+=( "--enable-perlinterp" )
-CFG_OPTS+=( "--enable-pythoninterp" )
-CFG_OPTS+=( "--with-python3-stable-abi" )
+CFG_OPTS+=( "--disable-pythoninterp" )
+CFG_OPTS+=( "--enable-python3interp=dynamic" )
+CFG_OPTS+=( "--with-python3-stable-abi=3.8" )
 CFG_OPTS+=( "--enable-rubyinterp" )
 CFG_OPTS+=( "--enable-luainterp" )
 CFG_OPTS+=( "--enable-tclinterp" )


### PR DESCRIPTION
* enables py3 as dynamic
* fixes the (previously unused, and broken) `--with-python3-stable-abi`
* disables py2

It would be possible to keep py2, however the documentation states that Vim "imprints itself" on whatever the user happens to run first (py2 / py3) and then **crashes** if the other version is requested. That doesn't sound like great behavior; plus py2 has been deprecated for a long time and Debian / Ubuntu also disable it.

I've discussed the pros of using `interp=dynamic` and the requirement to `set pythonthreedll` in #69 &mdash; this can be documented later.