### PR TITLE
Fix to FTBFS: revert python3 cfg to 20231112

### DIFF
--- a/scripts/build_vim.sh
+++ b/scripts/build_vim.sh
@@ -14,7 +14,7 @@ export CFLAGS="-Wno-deprecated-declarations"
 typeset -a CFG_OPTS
 CFG_OPTS+=( "--enable-perlinterp" )
 CFG_OPTS+=( "--enable-pythoninterp" )
-CFG_OPTS+=( "--with-python3-stable-abi" )
+CFG_OPTS+=( "--enable-python3interp" )
 CFG_OPTS+=( "--enable-rubyinterp" )
 CFG_OPTS+=( "--enable-luainterp" )
 CFG_OPTS+=( "--enable-tclinterp" )

--- a/scripts/build_vim.sh
+++ b/scripts/build_vim.sh
@@ -13,9 +13,8 @@ export CFLAGS="-Wno-deprecated-declarations"
 
 typeset -a CFG_OPTS
 CFG_OPTS+=( "--enable-perlinterp" )
-CFG_OPTS+=( "--disable-pythoninterp" )
-CFG_OPTS+=( "--enable-python3interp=dynamic" )
-CFG_OPTS+=( "--with-python3-stable-abi=3.8" )
+CFG_OPTS+=( "--enable-pythoninterp" )
+CFG_OPTS+=( "--with-python3-stable-abi" )
 CFG_OPTS+=( "--enable-rubyinterp" )
 CFG_OPTS+=( "--enable-luainterp" )
 CFG_OPTS+=( "--enable-tclinterp" )


### PR DESCRIPTION
This reverts both dee26b4 and 39f585d for `scripts/build_vim.sh`. For some reason it builds a `+python3/dyn`, even though it wasn't requested. It seems to even work on Debian 12 (python3 = 3.11): after `set pythonthreedll=libpython3.11.so`, both `:python3 print('hi')` and `:python3 import argparse` work.

Sample release built on 20.04: https://github.com/mralusw/vim-appimage-tst-upstream/releases/tag/v9.1.0265

Maybe Vim's `if_pyth.txt` docs are broken.