### PR TITLE
use GitHub's gh tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
 
       - name: Get latest tags
         id: latest-tags
-        uses: octokit/graphql-action@v2.x
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
+          owner: ${{ steps.param.outputs.owner }}
+          repo: ${{ steps.param.outputs.repo }}
           query: |
             query($owner:String!,$repo:String!) {
               appimage: repository(owner:$owner, name:$repo) {
@@ -45,16 +45,19 @@ jobs:
                 }
               }
             }
-          owner: ${{ steps.param.outputs.owner }}
-          repo: ${{ steps.param.outputs.repo }}
+          jq_extract: >+
+            "vim_tag=" + .data.vim.refs.edges[0].node.name,
+            "appimage_tag=" + .data.appimage.refs.edges[0].node.name
+        run: |
+          gh api graphql -F owner="$owner" -F repo="$repo" -f query="$query" --jq "$jq_extract" | \
+            tee -a "$GITHUB_ENV"
 
       - name: Check updates
         id: check-updates
         run: |
-          appimage_tag=${{ fromJSON(steps.latest-tags.outputs.data).appimage.refs.edges[0].node.name }}
-          vim_tag=${{ fromJSON(steps.latest-tags.outputs.data).vim.refs.edges[0].node.name }}
-          echo "appimagetag=${appimage_tag}" >> "$GITHUB_OUTPUT"
-          echo "updated=$([[ ${appimage_tag} != ${vim_tag} ]] && echo true)" >> "$GITHUB_OUTPUT"
+          printf >> "$GITHUB_OUTPUT" '%s\n' \
+           "appimagetag=${appimage_tag}" \
+           "updated=$([[ ${appimage_tag} != ${vim_tag} ]] && echo true)"
 
   create-appimage-job:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,10 @@ jobs:
           git push --follow-tags -u origin "${GITHUB_REF_NAME}"
 
       - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release.body
-          name: 'Vim: ${{ steps.commit.outputs.tag_name }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.commit.outputs.tag_name }}
-          files: |
-            *.AppImage
-            *.zsync
+        run: |
+          gh release create "$tag_name" \
+            *.AppImage *.zsync \
+            -F release.body -t "Vim: $tag_name"


### PR DESCRIPTION
[ [Test release](https://github.com/mralusw/vim-appimage-tst-upstream/releases/tag/v9.1.0283) in my `vim-appimage-tst-upstream` fork ]
 
GitHub's own `gh` tool comes pre-installed on runner images and obviates the need for some external actions. This reduces dependencies on external repos and (security-wise) avoids passing the GITHUB_TOKEN secret to external code in various states of maintenance.

## replace `octokit/graphql-action@v2.x` with `gh api graphql`

This action uses the (not just deprecated, but EOL'd since September 2023) Node 16, thus generating warnings; octokit seems to only update Node when GitHub completely pulls the rug (which can be months after a release EOL's). Other warnings are unavoidable due to how query parameters must be passed.

`gh` is also more flexible so it was possible to simplify logic a bit by writing to `$GITHUB_ENV` directly from the `--jq` argument (avoiding re-read / re-parse code).

## release using `gh release create` instead of `softprop`'s action

This doesn't change anything, but also removes an external dependency at no extra complexity cost.