### PR TITLE
use gcc-10 to compile and build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,8 @@ jobs:
             desktop-file-utils \
             libtool-bin \
             at-spi2-core \
-            libsodium-dev
+            libsodium-dev \
+            gcc-10
 
       - name: Update Vim
         run: |

--- a/scripts/build_vim.sh
+++ b/scripts/build_vim.sh
@@ -10,6 +10,7 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 SRCDIR=$script_dir/../vim/src
 FEATURES=huge
 export CFLAGS="-Wno-deprecated-declarations"
+export CC=gcc-10
 
 typeset -a CFG_OPTS
 CFG_OPTS+=( "--enable-perlinterp" )


### PR DESCRIPTION
gcc-9 seems to have a bug, which causes this error:

```
gcc -c -I. -I/usr/include/tcl8.6  -D_REENTRANT=1  -D_THREAD_SAFE=1  -D_LARGEFILE64_SOURCE=1  -Iproto -DHAVE_CONFIG_H     -Wno-deprecated-declarations  -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1         -o objects/if_tcl.o if_tcl.c
if_py_both.h: In function ‘ListItem’:
if_python3.c:312:24: error: dereferencing pointer to incomplete type ‘PyTypeObject’ {aka ‘struct _typeobject’}
  312 | # define PySlice_Type (*py3_PySlice_Type)
      |                        ^~~~~~~~~~~~~~~~~
/usr/include/python3.8/sliceobject.h:31:44: note: in expansion of macro ‘PySlice_Type’
   31 | #define PySlice_Check(op) (Py_TYPE(op) == &PySlice_Type)
      |                                            ^~~~~~~~~~~~
if_py_both.h:2745:14: note: in expansion of macro ‘PySlice_Check’
 2745 |     else if (PySlice_Check(idx))
      |              ^~~~~~~~~~~~~
gcc -c -I. -I/usr/include/ruby-2.7.0 -I/usr/include/x86_64-linux-gnu/ruby-2.7.0 -DRUBY_VERSION=27 -Iproto -DHAVE_CONFIG_H     -Wno-deprecated-declarations  -D_REENTRANT -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1         -o objects/if_ruby.o if_ruby.c
make: *** [Makefile:3308: objects/if_python3.o] Error 1
make: *** Waiting for unfinished jobs....
```

For some reason, this starts triggering after Vim patch: v9.1.0669