### PR TITLE
fix patch error

### DIFF
--- a/patch/02-disable-test-scrollbar.patch
+++ b/patch/02-disable-test-scrollbar.patch
@@ -1,5 +1,5 @@
 diff --git a/src/testdir/test_gui.vim b/src/testdir/test_gui.vim
-index 29259345c..9cbcadcba 100644
+index 9d319960b..4f81d0a22 100644
 --- a/src/testdir/test_gui.vim
 +++ b/src/testdir/test_gui.vim
 @@ -770,6 +770,9 @@ func Test_set_guioptions()
@@ -9,6 +9,6 @@ index 29259345c..9cbcadcba 100644
 +  if v:true
 +    throw 'Skipped: Disabling test on Vim-Appimage Repository'
 +  endif
-   " this test sometimes fails on CI
-   let g:test_is_flaky = 1
- 
+   " buffer with 200 lines
+   call setline(1, repeat(['one', 'two'], 100))
+   set scrolloff=0


### PR DESCRIPTION
Due to commit
https://github.com/vim/vim/commit/ea67ba718d8af10cb7aa3b91379203f5dd7e50d7

Error https://github.com/vim/vim-appimage/actions/runs/14919292836/job/41911499969
```
error: patch failed: src/testdir/test_gui.vim:770
error: src/testdir/test_gui.vim: patch does not apply
Error: Process completed with exit code 1.
```

re-generate patch `02-disable-test-scrollbar.patch` to pass CI.