### PR TITLE
Add `--without-wayland` on no GUI.

### DIFF
--- a/scripts/build_vim.sh
+++ b/scripts/build_vim.sh
@@ -36,7 +36,7 @@ cd "${SRCDIR}"
 rm -rf vim
 SHADOWDIR=vim make -e shadow
 pushd vim
-ADDITIONAL_ARG="--without-x --enable-gui=no --enable-fail-if-missing"
+ADDITIONAL_ARG="--without-x --enable-gui=no --enable-fail-if-missing --without-wayland"
 ./configure --with-features=$FEATURES "${CFG_OPTS[@]}" $ADDITIONAL_ARG
 make -j$NPROC
 popd


### PR DESCRIPTION
Fix #80 

I’ve applied a change to eliminate the dependency on Wayland. If it fits with the distribution policy, please consider merging it.